### PR TITLE
Add lit-profiler-helper package scaffolding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
 # lit-profiler-helper
+
+A helper library to profile LitElement component rendering.
+
+## Installation
+```bash
+npm install lit-profiler-helper
+```
+
+## Usage
+```ts
+import { enableLitProfiler } from 'lit-profiler-helper';
+
+enableLitProfiler({ logToConsole: true, emitEvents: true });
+```
+
+Optionally pair this library with a Chrome DevTools extension for better visualization.

--- a/index.ts
+++ b/index.ts
@@ -1,0 +1,1 @@
+export { enableLitProfiler } from './src/enableLitProfiler';

--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "lit-profiler-helper",
+  "version": "0.1.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "description": "A helper library to profile LitElement component rendering.",
+  "keywords": ["lit", "lit-element", "profiler", "web-components"],
+  "author": "Mapherez",
+  "license": "MIT",
+  "scripts": {
+    "build": "tsc"
+  },
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "peerDependencies": {
+    "lit": "^2 || ^3"
+  },
+  "devDependencies": {
+    "typescript": "^5"
+  }
+}

--- a/src/debug/emitDebugEvents.ts
+++ b/src/debug/emitDebugEvents.ts
@@ -1,0 +1,16 @@
+export interface DebugEvent {
+  type: string;
+  detail: any;
+}
+
+export function emitDebug(event: DebugEvent, logToConsole: boolean, emitEvents: boolean) {
+  const debugObj: any = (window as any).__litProfiler || ((window as any).__litProfiler = { events: [] });
+  debugObj.events.push(event);
+  if (logToConsole) {
+    // eslint-disable-next-line no-console
+    console.log('[lit-profiler]', event.type, event.detail);
+  }
+  if (emitEvents) {
+    window.dispatchEvent(new CustomEvent(`lit-profiler:${event.type}`, { detail: event.detail }));
+  }
+}

--- a/src/enableLitProfiler.ts
+++ b/src/enableLitProfiler.ts
@@ -1,0 +1,28 @@
+import { patchLifecycle } from './patches/patchLifecycle';
+import { wrapProperties } from './patches/wrapProperties';
+
+export interface ProfilerOptions {
+  logToConsole?: boolean;
+  emitEvents?: boolean;
+  autoLabelComponents?: boolean;
+  trackProperties?: boolean;
+}
+
+export function enableLitProfiler(options: ProfilerOptions = {}): void {
+  const opts = {
+    logToConsole: false,
+    emitEvents: false,
+    autoLabelComponents: false,
+    trackProperties: false,
+    ...options,
+  };
+  patchLifecycle({
+    logToConsole: opts.logToConsole,
+    emitEvents: opts.emitEvents,
+    autoLabel: opts.autoLabelComponents,
+    trackProperties: opts.trackProperties,
+  });
+  if (opts.trackProperties) {
+    wrapProperties();
+  }
+}

--- a/src/metadata/registerComponent.ts
+++ b/src/metadata/registerComponent.ts
@@ -1,0 +1,12 @@
+let idCounter = 0;
+const componentIds = new WeakMap<any, string>();
+
+export function registerComponent(instance: any, autoLabel: boolean): string {
+  let id = componentIds.get(instance);
+  if (!id) {
+    const name = autoLabel && instance.constructor?.name ? instance.constructor.name : 'LitComponent';
+    id = `${name}-${++idCounter}`;
+    componentIds.set(instance, id);
+  }
+  return id;
+}

--- a/src/patches/patchLifecycle.ts
+++ b/src/patches/patchLifecycle.ts
@@ -1,0 +1,29 @@
+import { emitDebug } from '../debug/emitDebugEvents';
+import { registerComponent } from '../metadata/registerComponent';
+import { LitElement } from 'lit';
+
+export interface PatchOptions {
+  logToConsole: boolean;
+  emitEvents: boolean;
+  autoLabel: boolean;
+  trackProperties: boolean;
+}
+
+const PATCHED = Symbol('lit-profiler-patched');
+
+export function patchLifecycle(opts: PatchOptions): void {
+  const proto = (LitElement as any).prototype as any;
+  if (proto[PATCHED]) return;
+  proto[PATCHED] = true;
+
+  const originalUpdate = proto.update;
+  proto.update = function (changedProperties: Map<string, unknown>) {
+    const id = registerComponent(this, opts.autoLabel);
+    const start = performance.now();
+    const result = originalUpdate.call(this, changedProperties);
+    const duration = performance.now() - start;
+    const props = opts.trackProperties && changedProperties ? Array.from(changedProperties.keys()) : undefined;
+    emitDebug({ type: 'render', detail: { id, duration, props } }, opts.logToConsole, opts.emitEvents);
+    return result;
+  };
+}

--- a/src/patches/wrapProperties.ts
+++ b/src/patches/wrapProperties.ts
@@ -1,0 +1,4 @@
+// Placeholder for future property diff tracking
+export function wrapProperties(): void {
+  // No-op in this simplified implementation
+}

--- a/src/utils/deepDiff.ts
+++ b/src/utils/deepDiff.ts
@@ -1,0 +1,14 @@
+export function deepDiff(obj1: any, obj2: any): any | undefined {
+  if (obj1 === obj2) return undefined;
+  if (typeof obj1 !== 'object' || typeof obj2 !== 'object') return obj2;
+  const diff: Record<string, any> = {};
+  const keys = new Set([...Object.keys(obj1 || {}), ...Object.keys(obj2 || {})]);
+  keys.forEach((key) => {
+    const value1 = (obj1 || {})[key];
+    const value2 = (obj2 || {})[key];
+    if (value1 !== value2) {
+      diff[key] = deepDiff(value1, value2);
+    }
+  });
+  return Object.keys(diff).length ? diff : undefined;
+}

--- a/src/utils/throttle.ts
+++ b/src/utils/throttle.ts
@@ -1,0 +1,11 @@
+export function throttle<T extends (...args: any[]) => void>(fn: T, wait: number): T {
+  let timer: number | undefined;
+  return function(this: unknown, ...args: Parameters<T>) {
+    if (timer === undefined) {
+      timer = window.setTimeout(() => {
+        timer = undefined;
+      }, wait);
+      fn.apply(this, args);
+    }
+  } as T;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "declaration": true,
+    "outDir": "dist",
+    "strict": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- set up TypeScript build configuration
- implement basic profiling patches and utilities
- expose `enableLitProfiler` entry point
- document package usage
- update package author

## Testing
- `npm install --no-save typescript@5`
- `npm install --no-save lit`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6859b8e3f798832c9bb8d1e68e62ea50