### PR TITLE
Add prop diffing and throttled render events

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,14 @@ npm install lit-profiler-helper
 ```ts
 import { enableLitProfiler } from 'lit-profiler-helper';
 
-enableLitProfiler({ logToConsole: true, emitEvents: true });
+enableLitProfiler({
+  logToConsole: true,
+  emitEvents: true,
+  trackProperties: true,
+});
 ```
+
+Setting `trackProperties` to `true` will include a deep diff of component
+properties in render events for easier inspection.
 
 Optionally pair this library with a Chrome DevTools extension for better visualization.

--- a/src/patches/patchLifecycle.ts
+++ b/src/patches/patchLifecycle.ts
@@ -1,6 +1,8 @@
 import { emitDebug } from '../debug/emitDebugEvents';
 import { registerComponent } from '../metadata/registerComponent';
 import { LitElement } from 'lit';
+import { deepDiff } from '../utils/deepDiff';
+import { throttle } from '../utils/throttle';
 
 export interface PatchOptions {
   logToConsole: boolean;
@@ -16,14 +18,36 @@ export function patchLifecycle(opts: PatchOptions): void {
   if (proto[PATCHED]) return;
   proto[PATCHED] = true;
 
+  const componentUpdateMap = new WeakMap<any, any>();
+  const throttleMap = new WeakMap<any, (detail: any) => void>();
+
   const originalUpdate = proto.update;
   proto.update = function (changedProperties: Map<string, unknown>) {
     const id = registerComponent(this, opts.autoLabel);
     const start = performance.now();
     const result = originalUpdate.call(this, changedProperties);
     const duration = performance.now() - start;
-    const props = opts.trackProperties && changedProperties ? Array.from(changedProperties.keys()) : undefined;
-    emitDebug({ type: 'render', detail: { id, duration, props } }, opts.logToConsole, opts.emitEvents);
+
+    let props: any = undefined;
+    let diff: any = undefined;
+
+    if (opts.trackProperties) {
+      const prevProps = componentUpdateMap.get(this) || {};
+      props = { ...this };
+      diff = deepDiff(prevProps, props);
+      componentUpdateMap.set(this, JSON.parse(JSON.stringify(props)));
+    }
+
+    let emit = throttleMap.get(this);
+    if (!emit) {
+      emit = throttle((detail: any) => {
+        emitDebug({ type: 'render', detail }, opts.logToConsole, opts.emitEvents);
+      }, 300, { trailing: true });
+      throttleMap.set(this, emit);
+    }
+
+    emit({ id, duration, props, propDiff: diff });
+
     return result;
   };
 }

--- a/src/utils/deepDiff.ts
+++ b/src/utils/deepDiff.ts
@@ -1,14 +1,57 @@
-export function deepDiff(obj1: any, obj2: any): any | undefined {
-  if (obj1 === obj2) return undefined;
-  if (typeof obj1 !== 'object' || typeof obj2 !== 'object') return obj2;
-  const diff: Record<string, any> = {};
-  const keys = new Set([...Object.keys(obj1 || {}), ...Object.keys(obj2 || {})]);
+export interface DiffResult {
+  changed: Record<string, any>;
+  added: Record<string, any>;
+  removed: Record<string, any>;
+}
+
+/**
+ * Recursively diff two objects and return maps of changed, added and removed
+ * values. Property paths are returned in dot notation.
+ */
+export function deepDiff(
+  obj1: any,
+  obj2: any,
+  path: string[] = []
+): DiffResult {
+  const result: DiffResult = {
+    changed: {},
+    added: {},
+    removed: {},
+  };
+
+  const keys = new Set([
+    ...Object.keys(obj1 || {}),
+    ...Object.keys(obj2 || {}),
+  ]);
+
   keys.forEach((key) => {
-    const value1 = (obj1 || {})[key];
-    const value2 = (obj2 || {})[key];
-    if (value1 !== value2) {
-      diff[key] = deepDiff(value1, value2);
+    const v1 = obj1 ? (obj1 as any)[key] : undefined;
+    const v2 = obj2 ? (obj2 as any)[key] : undefined;
+    const has1 = obj1 != null && Object.prototype.hasOwnProperty.call(obj1, key);
+    const has2 = obj2 != null && Object.prototype.hasOwnProperty.call(obj2, key);
+    const currentPath = [...path, key];
+    const pathStr = currentPath.join('.');
+
+    if (!has2) {
+      result.removed[pathStr] = v1;
+    } else if (!has1) {
+      result.added[pathStr] = v2;
+    } else if (v1 !== v2) {
+      if (
+        v1 &&
+        v2 &&
+        typeof v1 === 'object' &&
+        typeof v2 === 'object'
+      ) {
+        const sub = deepDiff(v1, v2, currentPath);
+        Object.assign(result.changed, sub.changed);
+        Object.assign(result.added, sub.added);
+        Object.assign(result.removed, sub.removed);
+      } else {
+        result.changed[pathStr] = v2;
+      }
     }
   });
-  return Object.keys(diff).length ? diff : undefined;
+
+  return result;
 }

--- a/src/utils/throttle.ts
+++ b/src/utils/throttle.ts
@@ -1,11 +1,42 @@
-export function throttle<T extends (...args: any[]) => void>(fn: T, wait: number): T {
+export interface ThrottleOptions {
+  leading?: boolean;
+  trailing?: boolean;
+}
+
+/**
+ * Throttle calls to `fn` so that it executes at most once every `wait` ms.
+ * By default it triggers on the leading edge only but can optionally trigger on
+ * the trailing edge of the burst as well.
+ */
+export function throttle<T extends (...args: any[]) => any>(
+  fn: T,
+  wait: number,
+  options: ThrottleOptions = {}
+): (...args: Parameters<T>) => void {
+  const { leading = true, trailing = false } = options;
   let timer: number | undefined;
-  return function(this: unknown, ...args: Parameters<T>) {
-    if (timer === undefined) {
+  let lastArgs: Parameters<T> | undefined;
+  let lastThis: any;
+
+  return function (this: any, ...args: Parameters<T>) {
+    if (!timer) {
+      if (leading) {
+        fn.apply(this, args);
+      } else if (trailing) {
+        lastArgs = args;
+        lastThis = this;
+      }
       timer = window.setTimeout(() => {
         timer = undefined;
+        if (trailing && lastArgs) {
+          fn.apply(lastThis, lastArgs);
+          lastArgs = undefined;
+          lastThis = undefined;
+        }
       }, wait);
-      fn.apply(this, args);
+    } else if (trailing) {
+      lastArgs = args;
+      lastThis = this;
     }
-  } as T;
+  };
 }


### PR DESCRIPTION
## Summary
- implement deep object diffing with change tracking
- add a generic throttle utility with trailing support
- track and emit property diff information from render lifecycle
- throttle render events
- document `trackProperties` option

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6859cfab88a8832c81c3fcd3a217efa0